### PR TITLE
修复错误日志不输出问题，springboot 1.5.10 的 web 里竟然没有自带的 logging，导致虽然用 slf4j 获取了 …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-logging -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
…logger，但是没有实际的 logger 去输出导致的问题

增加 springboot logging 的依赖